### PR TITLE
Fixing bug with dbt_profile_manager

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -52,8 +52,10 @@
       "Bash(# Find where the _read_folder_contents method ends\ngrep -n \"\"def _read_individual_files_and_union\"\" ingen_fab/python_libs/pyspark/flat_file_ingestion_pyspark.py)",
       "Bash(# Extract everything before line 369\nsed -n ''1,368p'' ingen_fab/python_libs/pyspark/flat_file_ingestion_pyspark.py > temp_file.py\n\n# Add the enhanced methods\ncat enhanced_precheck.py >> temp_file.py\n\n# Add everything from line 486 onwards (after the old method)\nsed -n ''486,$p'' ingen_fab/python_libs/pyspark/flat_file_ingestion_pyspark.py >> temp_file.py\n\n# Replace the original file\nmv temp_file.py ingen_fab/python_libs/pyspark/flat_file_ingestion_pyspark.py)",
       "Bash(touch:*)",
-      "Bash(cp:*)"
+      "Bash(cp:*)",
+      "Bash(uv run:*)"
     ],
-    "deny": []
+    "deny": [],
+    "defaultMode": "acceptEdits"
   }
 }

--- a/.devcontainer/spark_minimal/devcontainer.json
+++ b/.devcontainer/spark_minimal/devcontainer.json
@@ -29,6 +29,11 @@
 },
 "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/${localWorkspaceFolderBasename},type=bind",
 "workspaceFolder": "/workspaces/${localWorkspaceFolderBasename}",
-"remoteUser": "root"
+"remoteUser": "root",
+"portsAttributes": {
+  "54545": {
+    "label": "54545"
+  }
+}
 
 }

--- a/.pre-commit-config.local.yaml.bak
+++ b/.pre-commit-config.local.yaml.bak
@@ -11,9 +11,3 @@ repos:
         entry: ruff check --fix --force-exclude
         language: system
         types: [python]
-      - id: generate-cli-help-snippets
-        name: Generate CLI --help snippets
-        entry: python scripts/generate_cli_help_snippets.py
-        language: system
-        pass_filenames: false
-        files: ^ingen_fab/cli\.py$

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
     "mkdocs-get-deps==0.2.0",
     "mkdocs-git-revision-date-localized-plugin==1.4.7",
     "mkdocs-minify-plugin==0.8.0",
+    "mkdocs-mermaid2-plugin",
     "mike==2.1.3"
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -7,9 +7,6 @@ resolution-markers = [
     "sys_platform != 'darwin' and sys_platform != 'win32'",
 ]
 
-[options]
-prerelease-mode = "allow"
-
 [[package]]
 name = "agate"
 version = "1.9.1"
@@ -2089,6 +2086,15 @@ wheels = [
 ]
 
 [[package]]
+name = "editorconfig"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3a/a61d9a1f319a186b05d14df17daea42fcddea63c213bcd61a929fb3a6796/editorconfig-0.17.1.tar.gz", hash = "sha256:23c08b00e8e08cc3adcddb825251c497478df1dada6aefeb01e626ad37303745", size = 14695, upload-time = "2025-06-09T08:21:37.097Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/fd/a40c621ff207f3ce8e484aa0fc8ba4eb6e3ecf52e15b42ba764b457a9550/editorconfig-0.17.1-py3-none-any.whl", hash = "sha256:1eda9c2c0db8c16dbd50111b710572a5e6de934e39772de1959d41f64fc17c82", size = 16360, upload-time = "2025-06-09T08:21:35.654Z" },
+]
+
+[[package]]
 name = "fabric"
 version = "3.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2350,6 +2356,7 @@ docs = [
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-macros-plugin" },
     { name = "mkdocs-material" },
+    { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocs-nav-weight" },
     { name = "mkdocs-redirects" },
@@ -2415,6 +2422,7 @@ docs = [
     { name = "mkdocs-git-revision-date-localized-plugin", specifier = "==1.4.7" },
     { name = "mkdocs-macros-plugin", specifier = "==1.3.7" },
     { name = "mkdocs-material", specifier = "==9.6.15" },
+    { name = "mkdocs-mermaid2-plugin" },
     { name = "mkdocs-minify-plugin", specifier = "==0.8.0" },
     { name = "mkdocs-nav-weight", specifier = "==0.2.0" },
     { name = "mkdocs-redirects", specifier = "==1.2.2" },
@@ -2473,6 +2481,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/00/2a/e867e8531cf3e36b41201936b7fa7ba7b5702dbef42922193f05c8976cd6/jmespath-1.0.1.tar.gz", hash = "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe", size = 25843, upload-time = "2022-06-17T18:00:12.224Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/b4/b9b800c45527aadd64d5b442f9b932b00648617eb5d63d2c7a6587b7cafc/jmespath-1.0.1-py3-none-any.whl", hash = "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980", size = 20256, upload-time = "2022-06-17T18:00:10.251Z" },
+]
+
+[[package]]
+name = "jsbeautifier"
+version = "1.15.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "editorconfig" },
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/98/d6cadf4d5a1c03b2136837a435682418c29fdeb66be137128544cecc5b7a/jsbeautifier-1.15.4.tar.gz", hash = "sha256:5bb18d9efb9331d825735fbc5360ee8f1aac5e52780042803943aa7f854f7592", size = 75257, upload-time = "2025-02-27T17:53:53.252Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/14/1c65fccf8413d5f5c6e8425f84675169654395098000d8bddc4e9d3390e1/jsbeautifier-1.15.4-py3-none-any.whl", hash = "sha256:72f65de312a3f10900d7685557f84cb61a9733c50dcc27271a39f5b0051bf528", size = 94707, upload-time = "2025-02-27T17:53:46.152Z" },
 ]
 
 [[package]]
@@ -2871,6 +2892,23 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocs-mermaid2-plugin"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "jsbeautifier" },
+    { name = "mkdocs" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3e/1a/f580733da1924ebc9b4bb04a34ca63ae62a50b0e62eeb016e78d9dee6d69/mkdocs_mermaid2_plugin-1.2.1.tar.gz", hash = "sha256:9c7694c73a65905ac1578f966e5c193325c4d5a5bc1836727e74ac9f99d0e921", size = 16104, upload-time = "2024-11-02T06:27:36.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/ce/c8a41cb0f3044990c8afbdc20c853845a9e940995d4e0cffecafbb5e927b/mkdocs_mermaid2_plugin-1.2.1-py3-none-any.whl", hash = "sha256:22d2cf2c6867d4959a5e0903da2dde78d74581fc0b107b791bc4c7ceb9ce9741", size = 17260, upload-time = "2024-11-02T06:27:34.652Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces several configuration and code updates to improve environment setup, port labeling, and the handling of lakehouse preferences in the DBT profile manager. The most significant changes involve refactoring how lakehouse selection is stored and retrieved, updating devcontainer and pre-commit settings, and enhancing documentation build capabilities.

**DBT Profile Manager Improvements:**

* Refactored `get_saved_lakehouse_preference` in `dbt_profile_manager.py` to look up the saved lakehouse name using the standard `lakehouse` field, then map it back to the corresponding prefix by searching available lakehouses. This replaces the previous method that relied on a custom `_lakehouse_prefix` field.
* Removed logic from `generate_profile_config` in `dbt_profile_manager.py` that saved the selected prefix under the custom `_lakehouse_prefix` field, aligning with the new approach for preference lookup.

**Development Environment and Tooling:**

* Added a port label for port `54545` in `.devcontainer/spark_minimal/devcontainer.json` to improve port management and identification in the development container.
* Updated `.claude/settings.local.json` to allow `uv run:*` Bash commands and set the default mode to `acceptEdits`, improving the flexibility of command execution in the local environment.
* Removed the `generate-cli-help-snippets` pre-commit hook from `.pre-commit-config.local.yaml.bak`, streamlining pre-commit checks.

**Documentation:**

* Added the `mkdocs-mermaid2-plugin` to the `pyproject.toml` dependencies, enabling Mermaid diagram support in documentation builds.