### PR TITLE
Created functionality to allow manifest files to be saved in config lakehouse

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -19,6 +19,7 @@ Reference for environment variables used by the CLI and deploy workflows.
 | `POSTGRES_PORT` | Local testing | PostgreSQL port (default: 5432) | `5432` |
 | `POSTGRES_USER` | Local testing | PostgreSQL user (default: postgres) | `postgres` |
 | `POSTGRES_DATABASE` | Local testing | PostgreSQL database name (default: local) | `local` |
+| `WORKSPACE_MANIFEST_LOCATION` | Remote manifest file | Used to allow manifest file to be stored in config lakehouse | `config_lakehouse`, `local` |
 
 Notes:
 - The CLI falls back to `FABRIC_WORKSPACE_REPO_DIR` and `FABRIC_ENVIRONMENT` if not provided by flags.

--- a/ingen_fab/az_cli/onelake_utils.py
+++ b/ingen_fab/az_cli/onelake_utils.py
@@ -18,6 +18,8 @@ from ingen_fab.config_utils.variable_lib_factory import (
 )
 from ingen_fab.fabric_api.utils import FabricApiUtils
 
+import os
+
 try:
     from rich.console import Console
 
@@ -154,6 +156,85 @@ class OneLakeUtils:
                 f"Could not find lakehouse name for ID: {lakehouse_id} in workspace: {self.workspace_id}"
             )
         return lakehouse_name
+
+    def download_file_from_lakehouse(
+        self,
+        lakehouse_id: str,
+        file_path: str,
+        source_path: str = None,
+        *,
+        service_client: Optional[DataLakeServiceClient] = None,
+        file_system_client: Optional[FileSystemClient] = None,
+        verbose: bool = True,
+    ) -> dict:
+        """
+        Download a file from a lakehouse's Files section using Azure Storage SDK.
+
+        Args:
+            lakehouse_id: ID of the source lakehouse
+            file_path: Local path to the file to download
+            source_path: Path in the lakehouse (defaults to filename)
+            verbose: Whether to show individual file upload messages (default: True)
+
+        Returns:
+            Dictionary with upload result information
+        """
+        file_path_obj = Path(file_path)
+
+        #if not file_path_obj.exists():
+        #    raise FileNotFoundError(f"File not found: {file_path}")
+
+        if source_path is None:
+            source_path = file_path_obj.name
+
+        try:
+            # Use provided clients or create new ones
+            if service_client is None:
+                service_client = self._get_datalake_service_client()
+
+            if file_system_client is None:
+                workspace_name = self.workspace_name
+                file_system_client = service_client.get_file_system_client(
+                    workspace_name
+                )
+
+            # Get lakehouse name and construct the full path: {lakehouse_name}.Lakehouse/Files/{target_path}
+            lakehouse_name = self._get_lakehouse_name(lakehouse_id)
+            full_source_path = (
+                f"{lakehouse_name}.Lakehouse/Files/{source_path}".replace("\\", "/")
+            )
+
+            file_client = file_system_client.get_file_client(full_source_path)
+
+            if verbose and self.console:
+                self.console.print(
+                    f"[cyan]Uploading:[/cyan] {Path(file_path).name} → OneLake"
+                )
+
+            download = file_client.download_file()
+            
+            with open(file_path_obj, "wb") as my_file:
+                downloaded_bytes = download.readinto(my_file)
+
+            if verbose:
+                self.msg_helper.print_success(f"Downloaded {full_source_path}")
+            return {
+                "success": True,
+                "local_path": str(file_path),
+                "remote_path": full_source_path,
+                "lakehouse_id": lakehouse_id,
+            }
+
+        except Exception as e:
+            error_msg = f"Failed to download {full_source_path}: {str(e)}"
+            if verbose:
+                self.msg_helper.print_error(error_msg)
+            return {
+                "success": False,
+                "local_path": str(file_path),
+                "remote_path": source_path,
+                "error": error_msg,
+            }
 
     def upload_file_to_lakehouse(
         self,
@@ -413,6 +494,60 @@ class OneLakeUtils:
             )
             self.console.print(panel)
         return upload_results
+
+    def upload_manifest_file_to_config_lakehouse(
+        self, manifest_file_path: str = None
+    ) -> dict:
+        path_and_file = os.path.split(manifest_file_path)
+
+        directory_path = path_and_file[0]
+        file_name = path_and_file[1]
+
+        root_path = str(Path.cwd())
+
+        manifest_file_path_full = root_path + "\\" + directory_path + "\\" + file_name
+        
+        target_path = "ingen_fab/manifest/"+file_name
+        
+        service_client=self._get_datalake_service_client()
+        file_system_client = service_client.get_file_system_client(self.workspace_name)
+        lakehouse_id = self.get_config_lakehouse_id()
+
+        return self.upload_file_to_lakehouse(
+            lakehouse_id,
+            manifest_file_path_full,
+            target_path,
+            service_client=service_client,
+            file_system_client=file_system_client,
+            verbose=False, 
+        )
+
+    def download_manifest_file_from_config_lakehouse(
+        self, manifest_file_path: str = None
+    ) -> dict:
+        path_and_file = os.path.split(manifest_file_path)
+
+        directory_path = path_and_file[0]
+        file_name = path_and_file[1]
+
+        root_path = str(Path.cwd())
+
+        manifest_file_path_full = root_path + "\\" + directory_path + "\\" + file_name
+        
+        target_path = "ingen_fab/manifest/"+file_name
+        
+        service_client=self._get_datalake_service_client()
+        file_system_client = service_client.get_file_system_client(self.workspace_name)
+        lakehouse_id = self.get_config_lakehouse_id()
+
+        return self.download_file_from_lakehouse(
+            lakehouse_id,
+            manifest_file_path_full,
+            target_path,
+            service_client=service_client,
+            file_system_client=file_system_client,
+            verbose=False, 
+        )
 
     def upload_python_libs_to_config_lakehouse(
         self, python_libs_path: str = None

--- a/ingen_fab/fabric_cicd/promotion_utils.py
+++ b/ingen_fab/fabric_cicd/promotion_utils.py
@@ -22,6 +22,17 @@ from ingen_fab.cli_utils.console_styles import ConsoleStyles
 # from fabric_cicd.fabric_workspace import PublishLogEntry
 from ingen_fab.config_utils.variable_lib import VariableLibraryUtils
 
+from ingen_fab.az_cli.onelake_utils import OneLakeUtils
+
+from fabric_cicd import (
+    FabricWorkspace,
+    constants,
+    publish_all_items,
+    unpublish_all_orphan_items,
+    append_feature_flag
+)
+
+append_feature_flag("enable_shortcut_publish")
 
 class promotion_utils:
     """Utility class for promoting Fabric items between workspaces."""
@@ -172,6 +183,12 @@ class SyncToFabricEnvironment:
     def read_platform_manifest(
         self, manifest_path: Path
     ) -> Optional[SyncToFabricEnvironment.manifest]:
+        
+        onelake_utils = OneLakeUtils(
+            environment=self.environment, project_path=Path(self.project_path), console=self.console
+        )
+        results = onelake_utils.download_manifest_file_from_config_lakehouse(manifest_path)
+
         """Read the platform folders manifest from a YAML file."""
         ConsoleStyles.print_info(self.console, str(Path.cwd()))
         ConsoleStyles.print_info(
@@ -285,6 +302,11 @@ class SyncToFabricEnvironment:
             yaml.safe_dump(
                 manifest.__dict__, f, default_flow_style=False, sort_keys=False
             )
+        
+        onelake_utils = OneLakeUtils(
+            environment=self.environment, project_path=Path(self.project_path), console=self.console
+        )
+        results = onelake_utils.upload_manifest_file_to_config_lakehouse(output_path)
 
     def sync_environment(self):
         """Synchronize environment variables and platform folders. Upload to Fabric."""

--- a/ingen_fab/fabric_cicd/promotion_utils.py
+++ b/ingen_fab/fabric_cicd/promotion_utils.py
@@ -32,6 +32,8 @@ from fabric_cicd import (
     append_feature_flag
 )
 
+import os
+
 append_feature_flag("enable_shortcut_publish")
 
 class promotion_utils:
@@ -87,6 +89,7 @@ class SyncToFabricEnvironment:
         self.environment = environment
         self.target_workspace_id = None
         self.console = console or Console()
+        self.workspace_manifest_location = os.getenv('WORKSPACE_MANIFEST_LOCATION')
 
     @dataclass
     class manifest_item:
@@ -184,10 +187,14 @@ class SyncToFabricEnvironment:
         self, manifest_path: Path
     ) -> Optional[SyncToFabricEnvironment.manifest]:
         
-        onelake_utils = OneLakeUtils(
-            environment=self.environment, project_path=Path(self.project_path), console=self.console
-        )
-        results = onelake_utils.download_manifest_file_from_config_lakehouse(manifest_path)
+        if self.workspace_manifest_location == "config_lakehouse":
+            ConsoleStyles.print_info(
+                self.console, f"Downloading manifest file from config lakehouse"
+            )
+            onelake_utils = OneLakeUtils(
+                environment=self.environment, project_path=Path(self.project_path), console=self.console
+            )
+            results = onelake_utils.download_manifest_file_from_config_lakehouse(manifest_path)
 
         """Read the platform folders manifest from a YAML file."""
         ConsoleStyles.print_info(self.console, str(Path.cwd()))
@@ -303,10 +310,14 @@ class SyncToFabricEnvironment:
                 manifest.__dict__, f, default_flow_style=False, sort_keys=False
             )
         
-        onelake_utils = OneLakeUtils(
-            environment=self.environment, project_path=Path(self.project_path), console=self.console
-        )
-        results = onelake_utils.upload_manifest_file_to_config_lakehouse(output_path)
+        if self.workspace_manifest_location == "config_lakehouse":
+            ConsoleStyles.print_info(
+                self.console, f"Uploading manifest file to config lakehouse"
+            )
+            onelake_utils = OneLakeUtils(
+                environment=self.environment, project_path=Path(self.project_path), console=self.console
+            )
+            results = onelake_utils.upload_manifest_file_to_config_lakehouse(output_path)
 
     def sync_environment(self):
         """Synchronize environment variables and platform folders. Upload to Fabric."""


### PR DESCRIPTION
Changes:

**promotion_utils.py** 
- Logic to enable shortcut publish (as per Aydin)
- Changes to read_platform_manifest to download manifest file (depending on variable)
- Changes to save_platform_manifest to upload manifest file (depending on variable)
- 
**onelake_utils.py** 
- added download_file_from_lakehouse
- added upload_manifest_file_to_config_lakehouse
- added download_manifest_file_from_config_lakehouse

**environment-variables.md** 
- documented WORKSPACE_MANIFEST_LOCATION variable
