### PR TITLE
Improve deployment status tracking and error handling

### DIFF
--- a/ingen_fab/az_cli/onelake_utils.py
+++ b/ingen_fab/az_cli/onelake_utils.py
@@ -525,16 +525,12 @@ class OneLakeUtils:
     def download_manifest_file_from_config_lakehouse(
         self, manifest_file_path: str = None
     ) -> dict:
-        path_and_file = os.path.split(manifest_file_path)
+        manifest_path_obj = Path(manifest_file_path)
+        file_name = manifest_path_obj.name
 
-        directory_path = path_and_file[0]
-        file_name = path_and_file[1]
+        manifest_file_path_full = str(manifest_path_obj)
 
-        root_path = str(Path.cwd())
-
-        manifest_file_path_full = root_path + "\\" + directory_path + "\\" + file_name
-        
-        target_path = "ingen_fab/manifest/"+file_name
+        target_path = f"ingen_fab/manifest/{file_name}"
         
         service_client=self._get_datalake_service_client()
         file_system_client = service_client.get_file_system_client(self.workspace_name)

--- a/ingen_fab/fabric_cicd/promotion_utils.py
+++ b/ingen_fab/fabric_cicd/promotion_utils.py
@@ -10,11 +10,12 @@ from typing import Optional
 import yaml
 from fabric_cicd import (
     FabricWorkspace,
+    append_feature_flag,
     constants,
     publish_all_items,
     unpublish_all_orphan_items,
 )
-from fabric_cicd.publish_log_entry import PublishLogEntry
+from fabric_cicd._common._publish_log_entry import PublishLogEntry
 from rich.console import Console
 
 from ingen_fab.cli_utils.console_styles import ConsoleStyles
@@ -23,14 +24,6 @@ from ingen_fab.cli_utils.console_styles import ConsoleStyles
 from ingen_fab.config_utils.variable_lib import VariableLibraryUtils
 
 from ingen_fab.az_cli.onelake_utils import OneLakeUtils
-
-from fabric_cicd import (
-    FabricWorkspace,
-    constants,
-    publish_all_items,
-    unpublish_all_orphan_items,
-    append_feature_flag
-)
 
 import os
 
@@ -44,6 +37,7 @@ class promotion_utils:
         self.workspace_id = FabricWorkspace.workspace_id
         self.repository_directory = FabricWorkspace.repository_directory
         self.environment = FabricWorkspace.environment
+
         if FabricWorkspace.item_type_in_scope is None:
             self.item_type_in_scope = list(constants.ACCEPTED_ITEM_TYPES_UPN)
         else:
@@ -59,10 +53,12 @@ class promotion_utils:
             environment=self.environment,
         )
 
-    def publish_all(self) -> None:
+    def publish_all(self, items_to_include: list[str]= []) -> list[PublishLogEntry]:
         """Publish all items from the repository to the workspace."""
         ws = self._workspace()
-        publish_all_items(fabric_workspace_obj=ws)
+        append_feature_flag("enable_experimental_features")
+        append_feature_flag("enable_items_to_include")
+        return publish_all_items(fabric_workspace_obj=ws, items_to_include=items_to_include)
 
     def unpublish_orphans(self) -> None:
         """Remove items from the workspace that are not present in the repository."""
@@ -326,6 +322,91 @@ class SyncToFabricEnvironment:
             )
             results = onelake_utils.upload_manifest_file_to_config_lakehouse(output_path)
 
+    def _update_manifest_with_results(
+        self,
+        manifest_items: list[manifest_item],
+        status_entries: list[PublishLogEntry],
+        manifest_path: Path,
+    ) -> dict:
+        """
+        Update manifest with deployment results.
+
+        Returns:
+            Dict with 'deployed' and 'failed' item lists
+        """
+        deployed_items = []
+        failed_items = []
+
+        if not status_entries:
+            ConsoleStyles.print_warning(
+                self.console, "Warning: no status entries found."
+            )
+        else:
+            # Create lookup dict for O(n) instead of O(n*m)
+            status_lookup = {
+                f"{entry.name}.{entry.item_type}".lower(): entry
+                for entry in status_entries
+            }
+
+            # Update manifest items silently
+            for item in manifest_items:
+                entry = status_lookup.get(item.name.lower())
+                if entry:
+                    if entry.success:
+                        item.status = "deployed"
+                        deployed_items.append({'name': item.name})
+                    else:
+                        item.status = "failed"
+                        error_msg = (
+                            getattr(entry, 'error', None)
+                            or getattr(entry, 'message', None)
+                            or getattr(entry, 'error_message', None)
+                            or "Unknown error"
+                        )
+                        failed_items.append({
+                            'name': item.name,
+                            'error': error_msg
+                        })
+
+        # Save updated manifest
+        self.save_platform_manifest(
+            manifest_items, manifest_path, perform_hash_check=False
+        )
+
+        return {
+            'deployed': deployed_items,
+            'failed': failed_items
+        }
+
+    def _print_deployment_summary(self, results: dict, unchanged: int) -> None:
+        """Print deployment summary."""
+        deployed = results['deployed']
+        failed = results['failed']
+
+        if deployed:
+            self.console.print()
+            for item in deployed:
+                ConsoleStyles.print_success(self.console, f"{item['name']}: Deployed")
+
+        if failed:
+            self.console.print()
+            for item in failed:
+                ConsoleStyles.print_error(self.console, f"{item['name']}: Failed")
+                ConsoleStyles.print_dim(self.console, f"  {item['error']}")
+
+        self.console.print()
+        if failed:
+            ConsoleStyles.print_error(
+                self.console,
+                f"Deploy failed! Items: {len(deployed)} deployed, {len(failed)} failed, {unchanged} unchanged."
+            )
+        else:
+            ConsoleStyles.print_success(
+                self.console,
+                f"Deploy complete! Items: {len(deployed)} deployed, {len(failed)} failed, {unchanged} unchanged."
+            )
+        self.console.print()
+
     def sync_environment(self):
         """Synchronize environment variables and platform folders. Upload to Fabric."""
         # 1) Inject variables into template
@@ -448,8 +529,11 @@ class SyncToFabricEnvironment:
             )
 
             manifest_items_new_updated: list[SyncToFabricEnvironment.manifest_item] = [
-                f for f in manifest_items if f.status in ["new", "updated"]
+                f for f in manifest_items if f.status in ["new", "updated", "failed"]
             ]
+
+            # Initialize deployment results
+            results = {'deployed': [], 'failed': []}
 
             if manifest_items_new_updated:
                 ConsoleStyles.print_success(
@@ -457,93 +541,56 @@ class SyncToFabricEnvironment:
                     f"Found {len(manifest_items_new_updated)} folders to publish",
                 )
 
-                # add the name of items to publish to list[str]
-                items_to_publish = [
-                    f"{item.name}" for item in manifest_items_new_updated
-                ]
-
-                ConsoleStyles.print_info(
-                    self.console, f"Items to publish: {items_to_publish}"
-                )
+                items_to_publish = [f"{item.name}" for item in manifest_items_new_updated]
+                ConsoleStyles.print_info(self.console, f"Items to publish: {items_to_publish}")
 
                 _item_type_in_scope = os.getenv("ITEM_TYPES_TO_DEPLOY",'')
-
                 if _item_type_in_scope == '':
                     item_type_in_scope=[
-                                "VariableLibrary","DataPipeline","Environment","Notebook","Report","SemanticModel","Lakehouse","MirroredDatabase","CopyJob","Eventhouse","Reflex","Eventstream","Warehouse","SQLDatabase","GraphQLApi",
-                            ]
+                        "VariableLibrary","DataPipeline","Environment","Notebook","Report","SemanticModel","Lakehouse","MirroredDatabase","CopyJob","Eventhouse","Reflex","Eventstream","Warehouse","SQLDatabase","GraphQLApi",
+                    ]
                     ConsoleStyles.print_info(self.console, "Items to be published filter: None")
                 else:
                     ConsoleStyles.print_info(self.console, "Items to be published filter: " + _item_type_in_scope)
                     item_type_in_scope = [item.strip() for item in _item_type_in_scope.split(',')]
 
-                status_entries: list[PublishLogEntry]
-                status_entries = None
-                # After copying all folders, attempt to publish
                 ConsoleStyles.print_info(self.console, "\nPublishing items...")
+                status_entries: list[PublishLogEntry] = []
+
                 try:
                     fw = FabricWorkspace(
                         workspace_id=self.target_workspace_id,
-                        repository_directory=str(
-                            output_dir
-                        ),  # Changed: publish from output directory
+                        repository_directory=str(output_dir),
                         item_type_in_scope=item_type_in_scope,
                         environment="development",
                     )
-
+                    append_feature_flag("enable_experimental_features")
+                    append_feature_flag("enable_items_to_include")
                     status_entries = publish_all_items(
                         fabric_workspace_obj=fw, items_to_include=items_to_publish
                     )
-
-                    ConsoleStyles.print_success(
-                        self.console, "\nPublishing succeeded. Updating manifest..."
-                    )
-
                 except Exception as e:
-                    # If failed, update status to "failed"
                     ConsoleStyles.print_error(
                         self.console, f"\nPublishing failed with error: {e}"
                     )
-                finally:
-                    # Update status in manifest
-                    for item in manifest_items:
-                        if status_entries is None:
-                            ConsoleStyles.print_warning(
-                                self.console, "Warning: no status entries found."
-                            )
-                            break
-                        else:
-                            for entry in status_entries:
-                                # ConsoleStyles.print_info(self.console, f"Checking status for {entry.name}...")
-                                if (
-                                    f"{entry.name}.{entry.item_type}".lower()
-                                    == item.name.lower()
-                                ):
-                                    if entry.success:
-                                        item.status = "deployed"
-                                        ConsoleStyles.print_success(
-                                            self.console,
-                                            f"Item {item.name} deployed successfully",
-                                        )
-                                    break
-                    # Save updated manifest
-                    self.save_platform_manifest(
-                        manifest_items, manifest_path, perform_hash_check=False
-                    )
-                    ConsoleStyles.print_success(
-                        self.console, "Manifest updated with deployed status"
-                    )
 
-            else:
-                ConsoleStyles.print_info(
-                    self.console, "No folders with new/updated status to publish"
+                results = self._update_manifest_with_results(
+                    manifest_items, status_entries, manifest_path
                 )
+
+            # Calculate unchanged count
+            attempted_item_names = {item.name for item in manifest_items_new_updated}
+            unchanged_count = sum(
+                1 for item in manifest_items
+                if item.name not in attempted_item_names and item.status != "deleted"
+            )
+
+            self._print_deployment_summary(results, unchanged_count)
+
+            if results['failed']:
+                raise SystemExit(1)
         else:
             ConsoleStyles.print_warning(self.console, "Platform manifest not found")
-
-        ConsoleStyles.print_success(
-            self.console, "Promotion utilities initialized successfully."
-        )
 
     def clear_environment(self):
         # make an empty temp dir
@@ -567,7 +614,6 @@ class SyncToFabricEnvironment:
                 "Reflex",
                 "Eventstream",
                 "SQLDatabase",
-                "GraphQLApi",
             ],
             environment=self.environment,
         )

--- a/ingen_fab/fabric_cicd/promotion_utils.py
+++ b/ingen_fab/fabric_cicd/promotion_utils.py
@@ -179,10 +179,48 @@ class SyncToFabricEnvironment:
 
         return platform_folders
 
+    def _read_local_manifest_file(
+        self, manifest_path: Path
+    ) -> Optional[SyncToFabricEnvironment.manifest]:
+        """Read manifest from local file only, without remote download."""
+        if not manifest_path.exists():
+            return SyncToFabricEnvironment.manifest(
+                platform_folders=[],
+                generated_at=str(Path.cwd()),
+                version="1.0",
+            )
+
+        with open(manifest_path, "r", encoding="utf-8") as f:
+            try:
+                data = f.read()
+                if data.strip() == "":
+                    return SyncToFabricEnvironment.manifest(
+                        platform_folders=[],
+                        generated_at=str(Path.cwd()),
+                        version="1.0",
+                    )
+                else:
+                    manifest_data = yaml.safe_load(data)
+                    return SyncToFabricEnvironment.manifest(
+                        platform_folders=[
+                            SyncToFabricEnvironment.manifest_item(**item)
+                            for item in manifest_data.get("platform_folders", [])
+                        ],
+                        generated_at=manifest_data.get("generated_at"),
+                        version=manifest_data.get("version"),
+                    )
+            except yaml.YAMLError as e:
+                ConsoleStyles.print_error(
+                    self.console, f"Error reading manifest: {e}"
+                )
+                return None
+
     def read_platform_manifest(
         self, manifest_path: Path
     ) -> Optional[SyncToFabricEnvironment.manifest]:
-        
+        """Read the platform folders manifest, downloading from config lakehouse if configured."""
+
+        # If using config lakehouse, always attempt to download from lakehouse first
         if self.workspace_manifest_location == "config_lakehouse":
             ConsoleStyles.print_info(
                 self.console, f"Downloading manifest file from config lakehouse"
@@ -194,49 +232,42 @@ class SyncToFabricEnvironment:
                 config_lakehouse_id = onelake_utils.get_config_lakehouse_id()
                 onelake_utils._get_lakehouse_name(config_lakehouse_id)
                 results = onelake_utils.download_manifest_file_from_config_lakehouse(manifest_path)
+                if not results.get('success'):
+                    ConsoleStyles.print_info(
+                        self.console, f"Manifest not found in config lakehouse - will create new one."
+                    )
             except Exception as e:
+                print(e)
                 ConsoleStyles.print_info(
-                    self.console, f"Config lakehouse does not yet exist."
+                    self.console, f"Config lakehouse does not yet exist - will create new manifest."
                 )
 
-        """Read the platform folders manifest from a YAML file."""
+        # Now read the manifest file (either downloaded or local)
         ConsoleStyles.print_info(self.console, str(Path.cwd()))
         ConsoleStyles.print_info(
             self.console, f"Reading manifest from: {manifest_path}"
         )
+
         if manifest_path.exists():
-            with open(manifest_path, "r", encoding="utf-8") as f:
-                try:
-                    data = f.read()
-                    if data.strip() == "":
-                        ConsoleStyles.print_warning(
-                            self.console, "Manifest file is empty."
-                        )
-                        return SyncToFabricEnvironment.manifest(
-                            platform_folders=[],
-                            generated_at=str(Path.cwd()),
-                            version="1.0",
-                        )
-                    else:
-                        manifest_data = yaml.safe_load(data)
-                        return SyncToFabricEnvironment.manifest(
-                            platform_folders=[
-                                SyncToFabricEnvironment.manifest_item(**item)
-                                for item in manifest_data.get("platform_folders", [])
-                            ],
-                            generated_at=manifest_data.get("generated_at"),
-                            version=manifest_data.get("version"),
-                        )
-                except yaml.YAMLError as e:
-                    ConsoleStyles.print_error(
-                        self.console, f"Error reading manifest: {e}"
-                    )
-                    return None
+            return self._read_local_manifest_file(manifest_path)
         else:
-            ConsoleStyles.print_error(
-                self.console, f"Manifest file not found: {manifest_path}"
-            )
-            return None
+            # File doesn't exist locally
+            if self.workspace_manifest_location == "config_lakehouse":
+                # In config_lakehouse mode, return empty manifest for first deployment
+                ConsoleStyles.print_info(
+                    self.console, f"Creating new empty manifest for first deployment."
+                )
+                return SyncToFabricEnvironment.manifest(
+                    platform_folders=[],
+                    generated_at=str(Path.cwd()),
+                    version="1.0",
+                )
+            else:
+                # In local mode, file must exist
+                ConsoleStyles.print_error(
+                    self.console, f"Manifest file not found: {manifest_path}"
+                )
+                return None
 
     def save_platform_manifest(
         self,
@@ -244,10 +275,10 @@ class SyncToFabricEnvironment:
         output_path: Path,
         perform_hash_check: bool = True,
     ) -> None:
-        """Save the platform folders manifest to a YAML file."""
-        # Load existing manifest if it exists
+        """Save the platform folders manifest to a YAML file and upload to remote if configured."""
+        # Load existing manifest from local file only (don't download from remote)
         on_disk_manifest_items: list[SyncToFabricEnvironment.manifest_item] = []
-        existing_manifest = self.read_platform_manifest(manifest_path=output_path)
+        existing_manifest = self._read_local_manifest_file(manifest_path=output_path)
         if existing_manifest and existing_manifest.platform_folders:
             on_disk_manifest_items = existing_manifest.platform_folders
 
@@ -312,7 +343,9 @@ class SyncToFabricEnvironment:
             yaml.safe_dump(
                 manifest.__dict__, f, default_flow_style=False, sort_keys=False
             )
-        
+
+    def _upload_manifest_to_remote(self, manifest_path: Path) -> None:
+        """Upload manifest file to config lakehouse if configured."""
         if self.workspace_manifest_location == "config_lakehouse":
             ConsoleStyles.print_info(
                 self.console, f"Uploading manifest file to config lakehouse"
@@ -320,7 +353,7 @@ class SyncToFabricEnvironment:
             onelake_utils = OneLakeUtils(
                 environment=self.environment, project_path=Path(self.project_path), console=self.console
             )
-            results = onelake_utils.upload_manifest_file_to_config_lakehouse(output_path)
+            onelake_utils.upload_manifest_file_to_config_lakehouse(manifest_path)
 
     def _update_manifest_with_results(
         self,
@@ -475,7 +508,14 @@ class SyncToFabricEnvironment:
                 self.console, "No notebook files needed variable substitution"
             )
 
-        # 2) Find folders with platform files and generate hashes - SCAN THE OUTPUT DIRECTORY
+        # 2) Download manifest from remote if configured (PULL remote state)
+        manifest_path = Path(
+            f"{self.project_path}/platform_manifest_{self.environment}.yml"
+        )
+        ConsoleStyles.print_info(self.console, "\nLoading platform manifest...")
+        manifest = self.read_platform_manifest(manifest_path)
+
+        # 3) Find folders with platform files and generate hashes - SCAN THE OUTPUT DIRECTORY
         fabric_items_path = (
             output_dir  # Changed: scan the output directory, not the original
         )
@@ -493,9 +533,7 @@ class SyncToFabricEnvironment:
         platform_folders = self.find_platform_folders(
             fabric_items_path, adjust_paths=True
         )
-        manifest_path = Path(
-            f"{self.project_path}/platform_manifest_{self.environment}.yml"
-        )
+
         if platform_folders:
             ConsoleStyles.print_success(
                 self.console,
@@ -506,27 +544,25 @@ class SyncToFabricEnvironment:
                     self.console, f"  - {folder.name}: {folder.hash[:16]}..."
                 )
 
-            # Save manifest
+            # Save manifest locally (merge with downloaded manifest)
             self.save_platform_manifest(
                 platform_folders, manifest_path, perform_hash_check=True
             )
             ConsoleStyles.print_success(
                 self.console, f"\nSaved platform manifest to: {manifest_path}"
             )
+
+            # Re-read manifest after saving to get updated status
+            manifest = self._read_local_manifest_file(manifest_path)
         else:
             ConsoleStyles.print_warning(
                 self.console, "No folders with platform files found."
             )
 
         manifest_items: list[SyncToFabricEnvironment.manifest_item] = []
-        if manifest_path.exists():
-            ConsoleStyles.print_info(self.console, "\nLoading platform manifest...")
-            manifest: SyncToFabricEnvironment.manifest = self.read_platform_manifest(
-                manifest_path
-            )
-            manifest_items: list[SyncToFabricEnvironment.manifest_item] = (
-                manifest.platform_folders
-            )
+
+        if manifest:
+            manifest_items = manifest.platform_folders
 
             manifest_items_new_updated: list[SyncToFabricEnvironment.manifest_item] = [
                 f for f in manifest_items if f.status in ["new", "updated", "failed"]
@@ -586,6 +622,9 @@ class SyncToFabricEnvironment:
             )
 
             self._print_deployment_summary(results, unchanged_count)
+
+            # Upload manifest to remote at the very end (PUSH remote state)
+            self._upload_manifest_to_remote(manifest_path)
 
             if results['failed']:
                 raise SystemExit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "deltalake==1.0.2",
     "pyarrow==20.0.0",
     "azure-cli==2.76.0",
-    "fabric_cicd @ https://github.com/jrampono/fabric-cicd/archive/refs/tags/v0.0.1.tar.gz",
+    "fabric_cicd @ git+https://github.com/aitil-insight/fabric-cicd.git@fix-skipped-publish-errors",
     "azure-storage-file-datalake==12.21.0",
     "azure-storage-blob>=12.26.0",
     "lazy-import>=0.2.2",


### PR DESCRIPTION
 Key changes:
  - Added proper status tracking from the fabric_cicd publish operations
  - Split out manifest updates and summary printing into separate methods for clarity
  - Deployment now shows deployed/failed/unchanged counts with actual error messages
  - Failed deployments now exit with code 1 (was just logging before)

  Dependencies:
  - Updated to use the fix-skipped-publish-errors branch from fabric_cicd which returns proper status entries