### PR TITLE
Added --skip-profile-confirmation option to the 'dbt exec' command

### DIFF
--- a/ingen_fab/cli.py
+++ b/ingen_fab/cli.py
@@ -1182,13 +1182,19 @@ def synthetic_data_unified_generate(
 
 
 # ===== DBT WRAPPER COMMANDS =====
-
-
 @dbt_app.command(
-    "exec", context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+    "exec",
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
 )
 def dbt_exec(
     ctx: typer.Context,
+    skip_profile_confirmation: Annotated[
+        bool,
+        typer.Option(
+            "--skip-profile-confirmation",
+            help="Skip confirmation prompt when updating dbt profile",
+        ),
+    ] = False,
 ):
     """Run dbt_wrapper from within the Fabric workspace repo, then return to the original directory."""
     from ingen_fab.cli_utils.dbt_profile_manager import ensure_dbt_profile_for_exec
@@ -1202,7 +1208,7 @@ def dbt_exec(
 
     # Check and update dbt profile with exec-specific behavior
     # Always prompts if saved info is missing/invalid, notifies if using saved preference
-    if not ensure_dbt_profile_for_exec(ctx):
+    if not skip_profile_confirmation and not ensure_dbt_profile_for_exec(ctx):
         raise typer.Exit(code=1)
 
     # Locate the wrapper executable


### PR DESCRIPTION
Added a CLI option to bypass the dbt profile manager prompt when running the dbt exec command. 

Can now build a dbt project without user prompts. e.g. 

```pwsh
# Generate and convert metadata
ingen_fab deploy get-metadata --all 

ingen_fab dbt convert-metadata --dbt-project transform_cdm_dbt --skip-profile-confirmation

# Clean target directory for local build activities
ECHO 'Y' | ingen_fab dbt exec --skip-profile-confirmation -- stage run clean --project-dir transform_cdm_dbt

# Build dbt project and initialise profile. Once prompted select edw (LH_CDM_CMN) Lakehouse by number
ECHO 'Y' | ingen_fab dbt exec --skip-profile-confirmation -- stage run build --project-dir transform_cdm_dbt

# Generate Fabric notebooks to prepare for deployment
ECHO 'Y' | ingen_fab dbt exec --skip-profile-confirmation -- stage run post-scripts --project-dir transform_cdm_dbt

# Create Fabric notebook to be deployed to workspace
ingen_fab dbt create-notebooks --dbt-project transform_cdm_dbt  --skip-profile-confirmation
```