### PR TITLE
Support syncs for directory uploads to remove orphaned files

### DIFF
--- a/ingen_fab/az_cli/onelake_utils.py
+++ b/ingen_fab/az_cli/onelake_utils.py
@@ -157,6 +157,188 @@ class OneLakeUtils:
             )
         return lakehouse_name
 
+    def _list_remote_directory_files(
+        self,
+        lakehouse_id: str,
+        target_prefix: str,
+        *,
+        service_client: Optional[DataLakeServiceClient] = None,
+        file_system_client: Optional[FileSystemClient] = None,
+    ) -> set[str]:
+        """
+        List all files in a remote directory and return their relative paths.
+
+        Args:
+            lakehouse_id: ID of the lakehouse
+            target_prefix: Directory path within the Files section
+            service_client: Optional service client to reuse
+            file_system_client: Optional file system client to reuse
+
+        Returns:
+            Set of relative file paths (relative to target_prefix)
+        """
+        try:
+            if service_client is None:
+                service_client = self._get_datalake_service_client()
+
+            if file_system_client is None:
+                file_system_client = service_client.get_file_system_client(
+                    self.workspace_name
+                )
+
+            lakehouse_name = self._get_lakehouse_name(lakehouse_id)
+            base_path = f"{lakehouse_name}.Lakehouse/Files/{target_prefix}".replace(
+                "\\", "/"
+            )
+
+            remote_files = set()
+            paths = file_system_client.get_paths(path=base_path, recursive=True)
+
+            for path_item in paths:
+                if not path_item.is_directory:
+                    # Extract relative path from full OneLake path
+                    if "/Files/" in path_item.name:
+                        files_part = path_item.name.split("/Files/", 1)[1]
+                        if target_prefix and files_part.startswith(target_prefix + "/"):
+                            relative_path = files_part[len(target_prefix) + 1 :]
+                            remote_files.add(relative_path)
+
+            return remote_files
+
+        except Exception as e:
+            # If directory doesn't exist, return empty set (expected for first upload)
+            error_msg = str(e).lower()
+            if "not found" in error_msg or "does not exist" in error_msg:
+                return set()
+            # For other errors, log warning but continue
+            if self.console:
+                self.msg_helper.print_warning(
+                    f"Could not list remote directory '{target_prefix}': {str(e)}"
+                )
+            return set()
+
+    def _compute_sync_deletions(
+        self, local_files: set[str], remote_files: set[str]
+    ) -> set[str]:
+        """
+        Compute which remote files should be deleted to match local directory.
+
+        Args:
+            local_files: Set of local file paths (relative to source directory)
+            remote_files: Set of remote file paths (relative to target prefix)
+
+        Returns:
+            Set of file paths that exist remotely but not locally
+        """
+        return remote_files - local_files
+
+    def _delete_remote_files_parallel(
+        self,
+        lakehouse_id: str,
+        files_to_delete: set[str],
+        target_prefix: str,
+        *,
+        service_client: Optional[DataLakeServiceClient] = None,
+        file_system_client: Optional[FileSystemClient] = None,
+        max_workers: int = 8,
+    ) -> dict:
+        """
+        Delete multiple files from lakehouse in parallel with progress tracking.
+
+        Args:
+            lakehouse_id: ID of the lakehouse
+            files_to_delete: Set of relative file paths to delete
+            target_prefix: Directory prefix for the files
+            service_client: Optional service client to reuse
+            file_system_client: Optional file system client to reuse
+            max_workers: Number of parallel deletions
+
+        Returns:
+            Dictionary with deletion results (deleted count, failed count, errors)
+        """
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        if not files_to_delete:
+            return {"deleted": 0, "failed": 0, "errors": []}
+
+        # Create clients once for efficiency
+        if service_client is None:
+            service_client = self._get_datalake_service_client()
+        if file_system_client is None:
+            file_system_client = service_client.get_file_system_client(
+                self.workspace_name
+            )
+
+        deletion_results = {"deleted": 0, "failed": 0, "errors": []}
+
+        self.msg_helper.print_info(
+            f"Removing {len(files_to_delete)} files from remote that don't exist locally"
+        )
+
+        def delete_one(relative_path: str) -> dict:
+            full_path = f"{target_prefix}/{relative_path}".replace("\\", "/")
+            try:
+                if self.delete_lakehouse_file(
+                    lakehouse_id,
+                    full_path,
+                    service_client=service_client,
+                    file_system_client=file_system_client,
+                ):
+                    return {"success": True, "path": relative_path}
+                else:
+                    return {
+                        "success": False,
+                        "path": relative_path,
+                        "error": "Delete returned False",
+                    }
+            except Exception as e:
+                return {"success": False, "path": relative_path, "error": str(e)}
+
+        with self.progress_tracker.create_progress_bar(
+            len(files_to_delete), description="Deleting remote files..."
+        ) as progress:
+            task_id = self.progress_tracker.add_task(
+                "Deleting remote files...", len(files_to_delete)
+            )
+
+            with ThreadPoolExecutor(max_workers=max_workers) as executor:
+                future_to_file = {
+                    executor.submit(delete_one, file_path): file_path
+                    for file_path in files_to_delete
+                }
+
+                for future in as_completed(future_to_file):
+                    result = future.result()
+                    file_name = Path(result["path"]).name
+
+                    if result["success"]:
+                        deletion_results["deleted"] += 1
+                        if progress:
+                            self.progress_tracker.update_task(
+                                task_id,
+                                description=f"[green]✓[/green] {file_name}",
+                            )
+                    else:
+                        deletion_results["failed"] += 1
+                        deletion_results["errors"].append(
+                            result.get("error", "Unknown error")
+                        )
+                        if progress:
+                            self.progress_tracker.update_task(
+                                task_id, description=f"[red]✗[/red] {file_name}"
+                            )
+
+                    if progress:
+                        self.progress_tracker.advance_task(task_id)
+
+        # Only show failures; success will be in the final summary
+        if deletion_results["failed"] > 0:
+            self.msg_helper.print_warning(
+                f"{deletion_results['failed']} files failed to delete"
+            )
+
+        return deletion_results
+
     def download_file_from_lakehouse(
         self,
         lakehouse_id: str,
@@ -343,6 +525,7 @@ class OneLakeUtils:
         max_retries: int = 3,
         backoff_factor: float = 0.5,
         include_extensions: Optional[list[str]] = None,
+        sync_enabled: bool = True,
     ) -> dict:
         """
         Upload all files in a directory to a lakehouse's Files section using parallel uploads.
@@ -352,9 +535,13 @@ class OneLakeUtils:
             directory_path: Local directory path to upload
             target_prefix: Prefix for remote paths (optional)
             max_workers: Number of parallel uploads (default: 8)
+            max_retries: Maximum number of retry attempts for failed uploads (default: 3)
+            backoff_factor: Exponential backoff factor for retries (default: 0.5)
+            include_extensions: Optional list of file extensions to include (e.g., [".py", ".sql"])
+            sync_enabled: If True, delete remote files that don't exist locally (default: True)
 
         Returns:
-            Dictionary with upload results
+            Dictionary with upload and deletion results
         """
         from concurrent.futures import ThreadPoolExecutor, as_completed
 
@@ -362,7 +549,13 @@ class OneLakeUtils:
         if not dir_path.exists() or not dir_path.is_dir():
             raise ValueError(f"Directory not found: {directory_path}")
 
-        upload_results = {"successful": [], "failed": [], "total_files": 0}
+        upload_results = {
+            "successful": [],
+            "failed": [],
+            "total_files": 0,
+            "deleted": 0,
+            "deletion_failed": 0,
+        }
 
         # Find all files recursively, filtering out __ directories and by extension if specified
         all_files = []
@@ -395,6 +588,37 @@ class OneLakeUtils:
         if file_system_client is None:
             workspace_name = self.workspace_name
             file_system_client = service_client.get_file_system_client(workspace_name)
+
+        # Sync logic: delete remote files that don't exist locally
+        deletion_results = {"deleted": 0, "failed": 0, "errors": []}
+        if sync_enabled and target_prefix:
+            # Build set of local file relative paths
+            local_file_paths = set()
+            for file_path in all_files:
+                relative_path = str(file_path.relative_to(dir_path)).replace("\\", "/")
+                local_file_paths.add(relative_path)
+
+            # List remote files
+            remote_file_paths = self._list_remote_directory_files(
+                lakehouse_id,
+                target_prefix,
+                service_client=service_client,
+                file_system_client=file_system_client,
+            )
+
+            # Compute and execute deletions
+            files_to_delete = self._compute_sync_deletions(
+                local_file_paths, remote_file_paths
+            )
+            if files_to_delete:
+                deletion_results = self._delete_remote_files_parallel(
+                    lakehouse_id,
+                    files_to_delete,
+                    target_prefix,
+                    service_client=service_client,
+                    file_system_client=file_system_client,
+                    max_workers=max_workers,
+                )
 
         import time
 
@@ -466,30 +690,49 @@ class OneLakeUtils:
                     if progress:
                         self.progress_tracker.advance_task(task_id)
 
+        # Merge deletion results into upload_results
+        upload_results["deleted"] = deletion_results["deleted"]
+        upload_results["deletion_failed"] = deletion_results["failed"]
+
         # Show final results with rich formatting
         successful_count = len(upload_results["successful"])
         failed_count = len(upload_results["failed"])
+        deleted_count = upload_results["deleted"]
+        deletion_failed_count = upload_results["deletion_failed"]
 
-        if failed_count == 0:
-            self.msg_helper.print_success(
-                f"Upload completed: {successful_count} files uploaded successfully"
-            )
+        if failed_count == 0 and deletion_failed_count == 0:
+            # Build success message based on what operations occurred
+            if deleted_count > 0:
+                self.msg_helper.print_success(
+                    f"Sync completed: {successful_count} uploaded, {deleted_count} deleted"
+                )
+            else:
+                self.msg_helper.print_success(
+                    f"Upload completed: {successful_count} files uploaded successfully"
+                )
         else:
             self.msg_helper.print_warning(
-                f"Upload completed: {successful_count} successful, {failed_count} failed"
+                f"Sync completed with errors: {successful_count} uploaded, {failed_count} upload failed"
             )
 
         # Show summary panel
         if self.console:
             from rich.panel import Panel
 
-            summary_content = f"[green]✓ Successful:[/green] {successful_count}\n"
+            summary_content = f"[green]✓ Uploaded:[/green] {successful_count}\n"
             if failed_count > 0:
-                summary_content += f"[red]✗ Failed:[/red] {failed_count}"
+                summary_content += f"[red]✗ Upload failed:[/red] {failed_count}\n"
+            if deleted_count > 0:
+                summary_content += f"[yellow]🗑 Deleted:[/yellow] {deleted_count}\n"
+            if deletion_failed_count > 0:
+                summary_content += f"[red]✗ Deletion failed:[/red] {deletion_failed_count}"
+
+            # Remove trailing newline if present
+            summary_content = summary_content.rstrip("\n")
 
             panel = Panel(
                 summary_content,
-                title="[bold]Upload Summary[/bold]",
+                title="[bold]Directory Sync Summary[/bold]",
                 border_style="blue",
             )
             self.console.print(panel)
@@ -649,8 +892,7 @@ class OneLakeUtils:
             lakehouse_id=config_lakehouse_id,
             directory_path=str(dbt_project_path),
             target_prefix=f"{dbt_project_name}",
-            service_client=self._get_datalake_service_client(),
-            include_extensions=[".sql", ".yml", ".yaml", ".md", ".csv"],
+            service_client=self._get_datalake_service_client()
         )
 
     def list_lakehouse_files(

--- a/ingen_fab/packages/synapse_sync/ddl_scripts/lakehouse/log_synapse_extract_run_log_create.py.jinja
+++ b/ingen_fab/packages/synapse_sync/ddl_scripts/lakehouse/log_synapse_extract_run_log_create.py.jinja
@@ -11,6 +11,7 @@ schema = StructType([
     StructField("synapse_sync_fabric_pipeline_id", StringType(), True),
     StructField("synapse_datasource_name", StringType(), True),
     StructField("synapse_datasource_location", StringType(), True),
+    StructField("synapse_external_table_schema", StringType(), True),   
     StructField("source_schema_name", StringType(), True),
     StructField("source_table_name", StringType(), True),
     StructField("extract_mode", StringType(), True),

--- a/ingen_fab/packages/synapse_sync/templates/synapse_extract_daily_driver_notebook.py.jinja
+++ b/ingen_fab/packages/synapse_sync/templates/synapse_extract_daily_driver_notebook.py.jinja
@@ -131,6 +131,7 @@ else:
 # Inject Fabric variables from Variable Library value set
 SYNAPSE_DATASOURCE_NAME = "{% raw %}{{varlib:synapse_datasource_name}}{% endraw %}"
 SYNAPSE_DATASOURCE_LOCATION = "{% raw %}{{varlib:synapse_datasource_location}}{% endraw %}"
+SYNAPSE_EXTERNAL_TABLE_SCHEMA = "{% raw %}{{varlib:synapse_external_table_schema}}{% endraw %}"
 FABRIC_WORKSPACE_ID = "{% raw %}{{varlib:fabric_deployment_workspace_id}}{% endraw %}"
 FABRIC_LAKEHOUSE_ID = "{% raw %}{{varlib:config_lakehouse_id}}{% endraw %}"
 FABRIC_ENVIRONMENT = "{% raw %}{{varlib:fabric_environment}}{% endraw %}"
@@ -193,6 +194,7 @@ work_items = orchestrator.prepare_work_items(
     synapse_sync_fabric_pipeline_id = FABRIC_PIPELINE_ID,
     synapse_datasource_name = SYNAPSE_DATASOURCE_NAME,
     synapse_datasource_location = SYNAPSE_DATASOURCE_LOCATION,
+    synapse_external_table_schema = SYNAPSE_EXTERNAL_TABLE_SCHEMA,
     trigger_type=TRIGGER_TYPE,
     master_execution_parameters=MASTER_EXECUTION_PARAMETERS,
     work_items_json=None,  # None for daily mode
@@ -224,6 +226,7 @@ else:
             "synapse_sync_fabric_pipeline_id": wi.synapse_sync_fabric_pipeline_id,
             "synapse_datasource_name": wi.synapse_datasource_name,
             "synapse_datasource_location": wi.synapse_datasource_location,
+            "synapse_external_table_schema": wi.synapse_external_table_schema,
         }
         for wi in work_items
     ]

--- a/ingen_fab/packages/synapse_sync/templates/synapse_extract_retry_helper_notebook.py.jinja
+++ b/ingen_fab/packages/synapse_sync/templates/synapse_extract_retry_helper_notebook.py.jinja
@@ -82,6 +82,7 @@ nest_asyncio.apply()
 # Inject Fabric variables from Variable Library value set
 SYNAPSE_DATASOURCE_NAME = "{% raw %}{{varlib:synapse_datasource_name}}{% endraw %}"
 SYNAPSE_DATASOURCE_LOCATION = "{% raw %}{{varlib:synapse_datasource_location}}{% endraw %}"
+SYNAPSE_EXTERNAL_TABLE_SCHEMA = "{% raw %}{{varlib:synapse_external_table_schema}}{% endraw %}"
 FABRIC_WORKSPACE_ID = "{% raw %}{{varlib:fabric_deployment_workspace_id}}{% endraw %}"
 FABRIC_LAKEHOUSE_ID = "{% raw %}{{varlib:config_lakehouse_id}}{% endraw %}"
 FABRIC_ENVIRONMENT = "{% raw %}{{varlib:fabric_environment}}{% endraw %}"
@@ -193,6 +194,7 @@ if incomplete_extractions:
             # Prefer var-lib injected values
             "synapse_datasource_name": failure.get("synapse_datasource_name") or SYNAPSE_DATASOURCE_NAME,
             "synapse_datasource_location": failure.get("synapse_datasource_location") or SYNAPSE_DATASOURCE_LOCATION,
+            "synapse_external_table_schema": failure.get("synapse_external_table_schema") or SYNAPSE_EXTERNAL_TABLE_SCHEMA,
             # Run-scoped metadata for logging
             "trigger_type": TRIGGER_TYPE,
             "master_execution_parameters": ORIGINAL_MASTER_EXECUTION_PARAMETERS,

--- a/ingen_fab/python_libs/interfaces/synapse_orchestrator_interface.py
+++ b/ingen_fab/python_libs/interfaces/synapse_orchestrator_interface.py
@@ -32,6 +32,7 @@ class WorkItem:
     synapse_connection_name: Optional[str] = None
     synapse_datasource_name: Optional[str] = None
     synapse_datasource_location: Optional[str] = None
+    synapse_external_table_schema: Optional[str] = None
     export_base_dir: Optional[str] = None
     # Run-scoped metadata (single source of truth; avoid separate config dicts)
     trigger_type: Optional[str] = None
@@ -163,6 +164,7 @@ class SynapseOrchestratorInterface(ABC):
         synapse_sync_fabric_pipeline_id: Optional[str],
         synapse_datasource_name: str,
         synapse_datasource_location: str,
+        synapse_external_table_schema: str,
         *,
         trigger_type: Optional[str] = "Manual",
         master_execution_parameters: Optional[Dict[str, Any]] = None,

--- a/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
+++ b/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
@@ -312,14 +312,15 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                             "synapse_connection_name": getattr(work_item, "synapse_connection_name", None),
                             "synapse_datasource_name": getattr(work_item, "synapse_datasource_name", None) or "",
                             "synapse_datasource_location": getattr(work_item, "synapse_datasource_location", None) or "",
+                            "synapse_external_table_schema": getattr(work_item, "synapse_external_table_schema", None) or "",
                             "custom_select_sql": getattr(work_item, "custom_select_sql", None),
                         }
                         pipeline_params = extract_utils.build_pipeline_parameters_from_record(extraction_spec)
-                    except Exception:
-                        pipeline_params = None
+                    except Exception as e:
+                        logger.error(f"Error building pipeline parameters for {table_info}: {e}")
+                        raise e
                 if pipeline_params is None:
                     pipeline_params = self.get_pipeline_parameters(work_item, config)
-                
                 logger.info(f"Processing {table_info} - Triggering pipeline...")
                 
                 # Use pipeline id resolved during work item creation process
@@ -557,6 +558,7 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
         synapse_sync_fabric_pipeline_id: Optional[str],
         synapse_datasource_name: str,
         synapse_datasource_location: str,
+        synapse_external_table_schema: str,
         *,
         trigger_type: Optional[str] = "Manual",
         master_execution_parameters: Optional[Dict[str, Any]] = None,
@@ -643,6 +645,7 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                         synapse_sync_fabric_pipeline_id=resolved_pipeline_id,  # per‑item resolved value
                         synapse_datasource_name=resolved_ds_name,
                         synapse_datasource_location=resolved_ds_loc,
+                        synapse_external_table_schema=synapse_external_table_schema,
                         synapse_connection_name=item.get("synapse_connection_name"),
                         export_base_dir=item.get("export_base_dir"),
                         trigger_type=item.get("trigger_type") or trigger_type,
@@ -689,6 +692,7 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                                 synapse_connection_name=getattr(row, "synapse_connection_name", None),
                                 synapse_datasource_name=resolved_ds_name,
                                 synapse_datasource_location=resolved_ds_loc,
+                                synapse_external_table_schema=synapse_external_table_schema,
                                 export_base_dir=getattr(row, "export_base_dir", None),
                                 trigger_type=trigger_type,
                                 master_execution_parameters=master_execution_parameters,
@@ -717,6 +721,7 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                             synapse_connection_name=getattr(row, "synapse_connection_name", None),
                             synapse_datasource_name=resolved_ds_name,
                             synapse_datasource_location=resolved_ds_loc,
+                            synapse_external_table_schema=synapse_external_table_schema,
                             export_base_dir=getattr(row, "export_base_dir", None),
                             trigger_type=trigger_type,
                             master_execution_parameters=master_execution_parameters,


### PR DESCRIPTION
  ### Changes
  - Modified `upload_directory_to_lakehouse()` to delete remote files that don't exist locally
  - Added `sync_enabled` parameter (defaults to `True`) to enable/disable sync behavior
  - Directory uploads now ensure remote matches local exactly

  ### Implementation
  - `_list_remote_directory_files()` - lists remote files in target directory
  - `_compute_sync_deletions()` - compares local vs remote to find orphaned files
  - `_delete_remote_files_parallel()` - deletes orphaned files with progress tracking

  ### Impact
  - `upload_python_libs_to_config_lakehouse()` - now syncs deletions
  - `upload_dbt_project_to_config_lakehouse()` - now syncs deletions
