### PR TITLE
Require dbt project directory on dbt upload

### DIFF
--- a/ingen_fab/cli.py
+++ b/ingen_fab/cli.py
@@ -392,6 +392,7 @@ def upload_dbt_project(
         typer.Option(
             "--dbt-project",
             "-p",
+            prompt="dbt project directory",
             help="Name of the dbt project subdirectory (appended to the base project path)"
         )
     ]


### PR DESCRIPTION
Require dbt project directory to be specified on upload-dbt-project