### PR TITLE
Fix Bugs and Improve Performance

### DIFF
--- a/ingen_fab/python_libs/pyspark/ingestion/loading/loader.py
+++ b/ingen_fab/python_libs/pyspark/ingestion/loading/loader.py
@@ -482,8 +482,9 @@ class FileLoader:
         if file_format == "csv":
             # Two-pass for CSV: infer schema without corrupt record options
             options = self._get_file_read_options()
-            infer_options["samplingRatio"] = 0.01 # REF: UPDATE #3For inferring schema read 1% of data instead of loading the entire file. can be overwritten by config.
             infer_options = {k: v for k, v in options.items() if k not in ["columnNameOfCorruptRecord", "mode"]}
+            if not("samplingRatio" in infer_options):  # if samplingRatio not provided, add 0.01 as sampling ratio.
+                infer_options["samplingRatio"] = 0.01 # REF: UPDATE #3 For inferring schema read 1% of data instead of loading the entire file. can be overwritten by config.
             #infer_options["inferSchema"] = True  # REF : Bug #2 Shouldn't hard code as it will convert values and data is corrupted, the default is read all col as string. config can overwrite.
             inferred = self.source_lakehouse_utils.read_file(
                 file_path=file_paths,


### PR DESCRIPTION
 01-FEB-2026 - Fix bugs with Loader for Flat file ingestion

 BUG #1 - _infer_schema function checks has_header as boolean before applying given schema. has_header is string , but it was checking as bool
           The actual functionality required is to use the schema if schema is given, NOT only if there is no header. Otherwise STG and Target Table are 
           have different schema and thus doesn't load into target. - Fix to apply schema if s

 BUG #2  - Infer_schema is hardcoded, which is causing data to be transformed and creates data quality issue. Example a column wiht ID with values such as
            001, 002, 020 is loaded as 1, 2, 20 as it is hard configured to convert types and data is not usable- Fix the code to not hard_code infer_schema

 Update #3  - Peformance issue with CSV as the code reads the whole file twice, Once to find columns and data type ( shouldn't if schema is proivided)
           and the second time to write to the STG lakehouse. Fix the code to sample 0.01 ( i.e. 1% of data to address performance)

 Author : Sathish Senathi.