### PR TITLE
Feature/synapse sync logging

### DIFF
--- a/ingen_fab/python_libs/interfaces/synapse_extract_utils_interface.py
+++ b/ingen_fab/python_libs/interfaces/synapse_extract_utils_interface.py
@@ -83,7 +83,7 @@ class SynapseExtractUtilsInterface(ABC):
         pass
 
     @abstractmethod
-    def update_log_records(
+    def bulk_update_log_records(
         self,
         log_updates: List[Dict[str, Any]],
         max_retries: int = 5,

--- a/ingen_fab/python_libs/interfaces/synapse_extract_utils_interface.py
+++ b/ingen_fab/python_libs/interfaces/synapse_extract_utils_interface.py
@@ -83,6 +83,29 @@ class SynapseExtractUtilsInterface(ABC):
         pass
 
     @abstractmethod
+    def update_log_records(
+        self,
+        log_updates: List[Dict[str, Any]],
+        max_retries: int = 5,
+    ) -> bool:
+        """
+        Bulk update multiple log records with a single MERGE operation.
+
+        Each entry in log_updates must contain:
+            - master_execution_id: str
+            - execution_id: str
+            - updates: dict[str, Any]  — fields to set, e.g. status, end_timestamp, duration_sec
+
+        Args:
+            log_updates: List of update descriptors collected from process_extract calls.
+            max_retries: Maximum number of retry attempts.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        pass
+
+    @abstractmethod
     def get_queued_extracts(
         self,
         master_execution_id: str,

--- a/ingen_fab/python_libs/interfaces/synapse_orchestrator_interface.py
+++ b/ingen_fab/python_libs/interfaces/synapse_orchestrator_interface.py
@@ -108,7 +108,7 @@ class SynapseOrchestratorInterface(ABC):
         synapse_sync_fabric_pipeline_id: Optional[str] = None,
         extract_utils: Optional[Any] = None,
         execution_id: Optional[str] = None,
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> Tuple[bool, Optional[str], List[Dict[str, Any]]]:
         """
         Process a single extraction with complete lifecycle management.
 
@@ -123,7 +123,8 @@ class SynapseOrchestratorInterface(ABC):
             execution_id: Optional pre-logged execution_id for log updates
 
         Returns:
-            Tuple of (success_flag, error_message)
+            Tuple of (success_flag, error_message, log_updates) where log_updates is a list
+            of dicts each containing master_execution_id, execution_id, and updates to apply.
         """
         pass
 

--- a/ingen_fab/python_libs/pyspark/synapse_extract_utils.py
+++ b/ingen_fab/python_libs/pyspark/synapse_extract_utils.py
@@ -303,6 +303,119 @@ class SynapseExtractUtils(SynapseExtractUtilsInterface):
         
         return self.with_retry(_perform_update, max_retries=max_retries)
 
+    def update_log_records(
+        self,
+        log_updates: List[Dict[str, Any]],
+        max_retries: int = 5,
+    ) -> bool:
+        """Bulk update log records with a single MERGE operation.
+
+        Each entry in log_updates must contain:
+            - master_execution_id: str
+            - execution_id: str
+            - updates: dict[str, Any]  — fields to set, e.g. status, end_timestamp, duration_sec
+
+        Args:
+            log_updates: List of update descriptors collected from process_extract calls.
+            max_retries: Maximum number of retry attempts.
+
+        Returns:
+            True if successful, False otherwise.
+        """
+        if not log_updates:
+            logger.debug("update_log_records: no updates to apply, skipping.")
+            return True
+
+        def _perform_bulk_update() -> bool:
+            try:
+                spark = SparkSession.getActiveSession()
+                if not spark:
+                    raise RuntimeError("No active Spark session found")
+
+                ts_now = datetime.now(timezone.utc).replace(microsecond=0)
+
+                # Flatten each descriptor into a single row dict
+                rows: list[dict[str, Any]] = []
+                for entry in log_updates:
+                    row: dict[str, Any] = {
+                        "master_execution_id": str(entry["master_execution_id"]),
+                        "execution_id": str(entry["execution_id"]),
+                    }
+                    for k, v in entry.get("updates", {}).items():
+                        if k not in ("master_execution_id", "execution_id"):
+                            row[k] = v
+
+                    # Populate end_timestamp / end_timestamp_int for terminal rows
+                    if row.get("status") in self.TERMINAL_STATUSES:
+                        row.setdefault("end_timestamp", ts_now)
+                        et = row["end_timestamp"]
+                        if isinstance(et, datetime) and "end_timestamp_int" not in row:
+                            row["end_timestamp_int"] = int(
+                                f"{et.strftime('%Y%m%d%H%M%S')}{int(et.microsecond / 1000):03d}"
+                            )
+
+                    rows.append(row)
+
+                # Collect all update column names across every row
+                update_cols: set[str] = set()
+                for row in rows:
+                    update_cols.update(k for k in row if k not in ("master_execution_id", "execution_id"))
+
+                # Build a unified schema: fixed key fields + dynamic update fields
+                schema_fields = [
+                    StructField("master_execution_id", StringType(), True),
+                    StructField("execution_id", StringType(), True),
+                ]
+                for col_name in sorted(update_cols):
+                    if col_name == "execution_group":
+                        schema_fields.append(StructField(col_name, IntegerType(), True))
+                    elif col_name == "duration_sec":
+                        schema_fields.append(StructField(col_name, DoubleType(), True))
+                    elif col_name in ("start_timestamp", "end_timestamp"):
+                        schema_fields.append(StructField(col_name, TimestampType(), True))
+                    elif col_name == "end_timestamp_int":
+                        schema_fields.append(StructField(col_name, LongType(), True))
+                    elif col_name in ("extract_start_dt", "extract_end_dt"):
+                        schema_fields.append(StructField(col_name, DateType(), True))
+                    else:
+                        schema_fields.append(StructField(col_name, StringType(), True))
+
+                # Ensure every row has all columns (None where absent)
+                for row in rows:
+                    for col_name in update_cols:
+                        row.setdefault(col_name, None)
+
+                updates_df = spark.createDataFrame(rows, schema=StructType(schema_fields))
+
+                delta_log_table = DeltaTable.forPath(spark, self.log_table_uri)
+
+                merge_condition = (
+                    "target.master_execution_id = source.master_execution_id AND "
+                    "target.execution_id = source.execution_id"
+                )
+
+                update_expr = {col_name: f"source.{col_name}" for col_name in sorted(update_cols)}
+
+                delta_log_table.alias("target").merge(
+                    updates_df.alias("source"),
+                    merge_condition,
+                ).whenMatchedUpdate(set=update_expr).execute()
+
+                logger.info(
+                    "update_log_records: successfully merged %d log updates.", len(rows)
+                )
+                return True
+
+            except Exception as e:
+                if self.is_concurrent_write_error(e):
+                    logger.warning(f"Concurrent write error during bulk update, will retry: {e}")
+                    raise
+                else:
+                    logger.error(f"Non-retryable error during bulk update: {e}")
+                    raise
+
+        return self.with_retry(_perform_bulk_update, max_retries=max_retries)
+
     def get_queued_extracts(
         self,
         master_execution_id: str,

--- a/ingen_fab/python_libs/pyspark/synapse_extract_utils.py
+++ b/ingen_fab/python_libs/pyspark/synapse_extract_utils.py
@@ -303,7 +303,7 @@ class SynapseExtractUtils(SynapseExtractUtilsInterface):
         
         return self.with_retry(_perform_update, max_retries=max_retries)
 
-    def update_log_records(
+    def bulk_update_log_records(
         self,
         log_updates: List[Dict[str, Any]],
         max_retries: int = 5,
@@ -323,7 +323,7 @@ class SynapseExtractUtils(SynapseExtractUtilsInterface):
             True if successful, False otherwise.
         """
         if not log_updates:
-            logger.debug("update_log_records: no updates to apply, skipping.")
+            logger.debug("bulk_update_log_records: no updates to apply, skipping.")
             return True
 
         def _perform_bulk_update() -> bool:
@@ -402,7 +402,7 @@ class SynapseExtractUtils(SynapseExtractUtilsInterface):
                 ).whenMatchedUpdate(set=update_expr).execute()
 
                 logger.info(
-                    "update_log_records: successfully merged %d log updates.", len(rows)
+                    "bulk_update_log_records: successfully merged %d log updates.", len(rows)
                 )
                 return True
 

--- a/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
+++ b/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
@@ -407,16 +407,19 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                 error_message = str(exc)
                 logger.error(f"Error processing {table_info} - Duration: {duration_sec:.2f}s", exc_info=True)
                 if extract_utils and execution_id:
-                    log_updates.append({
-                        "master_execution_id": master_execution_id,
-                        "execution_id": execution_id,
-                        "updates": {
-                            "status": "Failed",
-                            "error_messages": error_message,
-                            "end_timestamp": datetime.now(timezone.utc),
-                            "duration_sec": float(duration_sec),
-                        },
-                    })
+                    try:
+                        log_updates.append({
+                            "master_execution_id": master_execution_id,
+                            "execution_id": execution_id,
+                            "updates": {
+                                "status": "Failed",
+                                "error_messages": error_message,
+                                "end_timestamp": datetime.now(timezone.utc),
+                                "duration_sec": float(duration_sec),
+                            },
+                        })
+                    except Exception:
+                        logger.debug("Log update failed when handling unexpected error; continuing")
                 return False, error_message, log_updates
 
     async def run_async_orchestration(

--- a/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
+++ b/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
@@ -38,7 +38,7 @@ logger = logging.getLogger(__name__)
 
 # Constants
 DEFAULT_MAX_CONCURRENCY = 10
-POLL_INTERVAL = 60
+POLL_INTERVAL = 10
 FAST_RETRY_SEC = 10
 POLL_TIMEOUT_SEC = 1800  # 30 minutes
 GRACE_WINDOW_SEC = 60    # Grace period for job appearance/early states
@@ -147,7 +147,7 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
         trigger_url = f"v1/workspaces/{workspace_id}/items/{pipeline_id}/jobs/instances?jobType=Pipeline"
 
         # Initial jitter to spread concurrent requests
-        initial_jitter = np.random.uniform(0, 10.0)
+        initial_jitter = np.random.uniform(0, 3)
         await asyncio.sleep(initial_jitter)
         
         try:
@@ -183,7 +183,7 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
         pipeline_id: str,
         job_id: str,
         timeout_minutes: int = POLL_TIMEOUT_SEC // 60,
-        polling_interval: int = 60,
+        polling_interval: int = POLL_INTERVAL,
         fast_retry_sec: int = FAST_RETRY_SEC
     ) -> Tuple[str, bool, Optional[str]]:
         """Poll a pipeline job until completion with advanced error handling."""
@@ -269,13 +269,14 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
         synapse_sync_fabric_pipeline_id: Optional[str] = None,
         extract_utils: Any | None = None,
         execution_id: str | None = None,
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> Tuple[bool, Optional[str], List[Dict[str, Any]]]:
         """Process a single extraction with complete lifecycle management."""
         table_info = f"{work_item.source_schema_name}.{work_item.source_table_name}"
-        
+        log_updates: list[dict[str, Any]] = []
+
         async with semaphore:
             start_time = time.monotonic()
-            
+
             try:
                 # Configuration object is optional; validate only when provided
                 # Pipeline workspace comes from explicit parameter 'pipeline_workspace_id'.
@@ -341,36 +342,17 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                 if not trigger_success or not job_id:
                     error_msg = "Failed to trigger pipeline"
                     logger.error(f"Error triggering pipeline for {table_info}")
-                    # Update log record as failed if available
-                    if extract_utils and execution_id:
-                        try:
-                            extract_utils.update_log_record(
-                                master_execution_id=master_execution_id,
-                                execution_id=execution_id,
-                                updates={
-                                    "status": "Failed",
-                                    "error_messages": error_msg,
-                                },
-                            )
-                        except Exception:
-                            logger.debug("Log update failed on trigger error; continuing")
-                    return False, error_msg
-                
-                # Update log: mark as Running and set pipeline_job_id (UTC timestamps)
-                if extract_utils and execution_id:
-                    try:
-                        extract_utils.update_log_record(
-                            master_execution_id=master_execution_id,
-                            execution_id=execution_id,
-                            updates={
-                                "status": "Running",
-                                "pipeline_job_id": job_id,
-                                "start_timestamp": datetime.now(timezone.utc),
+                    if execution_id:
+                        log_updates.append({
+                            "master_execution_id": master_execution_id,
+                            "execution_id": execution_id,
+                            "updates": {
+                                "status": "Failed",
+                                "error_messages": error_msg,
                             },
-                        )
-                    except Exception:
-                        logger.debug("Log update failed when marking Running; continuing")
-
+                        })
+                    return False, error_msg, log_updates
+                
                 logger.info(f"Running {table_info} - Job ID: {job_id}")
 
                 # Poll for completion
@@ -380,63 +362,53 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                     job_id=job_id,
                     timeout_minutes=30
                 )
-                
+
                 duration_sec = time.monotonic() - start_time
-                
+
                 if poll_success:
                     logger.info(f"{final_state} - {table_info} - Duration: {duration_sec:.2f}s")
-                    # Update log: Completed
                     if extract_utils and execution_id:
-                        try:
-                            extract_utils.update_log_record(
-                                master_execution_id=master_execution_id,
-                                execution_id=execution_id,
-                                updates={
-                                    "status": "Completed",
-                                    "end_timestamp": datetime.now(timezone.utc),
-                                    "duration_sec": float(duration_sec),
-                                },
-                            )
-                        except Exception:
-                            logger.debug("Log update failed when marking Completed; continuing")
-                    return True, None
+                        log_updates.append({
+                            "master_execution_id": master_execution_id,
+                            "execution_id": execution_id,
+                            "updates": {
+                                "status": "Completed",
+                                "end_timestamp": datetime.now(timezone.utc),
+                                "duration_sec": float(duration_sec),
+                            },
+                        })
+                    return True, None, log_updates
                 else:
                     logger.warning(f"{final_state} - {table_info} - Duration: {duration_sec:.2f}s")
                     if extract_utils and execution_id:
-                        try:
-                            extract_utils.update_log_record(
-                                master_execution_id=master_execution_id,
-                                execution_id=execution_id,
-                                updates={
-                                    "status": final_state if final_state else "Failed",
-                                    "error_messages": error_msg or "",
-                                    "end_timestamp": datetime.now(timezone.utc),
-                                    "duration_sec": float(duration_sec),
-                                },
-                            )
-                        except Exception:
-                            logger.debug("Log update failed when marking terminal state; continuing")
-                    return False, error_msg
+                        log_updates.append({
+                            "master_execution_id": master_execution_id,
+                            "execution_id": execution_id,
+                            "updates": {
+                                "status": final_state if final_state else "Failed",
+                                "error_messages": error_msg or "",
+                                "end_timestamp": datetime.now(timezone.utc),
+                                "duration_sec": float(duration_sec),
+                            },
+                        })
+                    return False, error_msg, log_updates
                     
             except Exception as exc:
                 duration_sec = time.monotonic() - start_time
                 error_message = str(exc)
                 logger.error(f"Error processing {table_info} - Duration: {duration_sec:.2f}s", exc_info=True)
                 if extract_utils and execution_id:
-                    try:
-                        extract_utils.update_log_record(
-                            master_execution_id=master_execution_id,
-                            execution_id=execution_id,
-                            updates={
-                                "status": "Failed",
-                                "error_messages": error_message,
-                                "end_timestamp": datetime.now(timezone.utc),
-                                "duration_sec": float(duration_sec),
-                            },
-                        )
-                    except Exception:
-                        logger.debug("Log update failed when handling unexpected error; continuing")
-                return False, error_message
+                    log_updates.append({
+                        "master_execution_id": master_execution_id,
+                        "execution_id": execution_id,
+                        "updates": {
+                            "status": "Failed",
+                            "error_messages": error_message,
+                            "end_timestamp": datetime.now(timezone.utc),
+                            "duration_sec": float(duration_sec),
+                        },
+                    })
+                return False, error_message, log_updates
 
     async def run_async_orchestration(
         self,
@@ -480,10 +452,10 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
             grouped.setdefault(wi.execution_group, []).append(wi)
         execution_groups = sorted(grouped.keys())
 
-        # Pair of (WorkItem, (success, error)) for reliable aggregation
-        all_pairs: List[Tuple[WorkItem, Tuple[bool, Optional[str]]]] = []
+        # Pair of (WorkItem, (success, error, log_updates)) for reliable aggregation
+        all_pairs: List[Tuple[WorkItem, Tuple[bool, Optional[str], List[Dict[str, Any]]]]] = []
 
-        async def run_one(item: WorkItem) -> Tuple[WorkItem, Tuple[bool, Optional[str]]]:
+        async def run_one(item: WorkItem) -> Tuple[WorkItem, Tuple[bool, Optional[str], List[Dict[str, Any]]]]:
             # Build composite key and resolve execution_id
             key = f"{item.source_schema_name}.{item.source_table_name}|{item.extract_start_dt or ''}|{item.extract_end_dt or ''}|{item.extract_mode}"
             ext_table = external_table_map.get(key) if external_table_map else None
@@ -542,6 +514,16 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
             if not res[0]
         ]
 
+        # Collect all log updates from every extraction
+        all_log_updates: List[Dict[str, Any]] = [update for _, res in all_pairs for update in res[2]]
+
+        # Bulk flush all log updates in a single MERGE
+        if extract_utils is not None and all_log_updates:
+            try:
+                extract_utils.update_log_records(all_log_updates)
+            except Exception as exc:
+                logger.warning(f"Bulk log update failed, continuing: {exc}")
+
         return {
             "master_execution_id": master_execution_id,
             "total_tables": total,
@@ -551,6 +533,7 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
             "execution_groups": execution_groups,
             "failed_details": failed_details,
             "completion_time": datetime.now(timezone.utc).isoformat(),
+            "log_updates": all_log_updates,
         }
 
     def prepare_work_items(

--- a/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
+++ b/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
@@ -342,15 +342,18 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                 if not trigger_success or not job_id:
                     error_msg = "Failed to trigger pipeline"
                     logger.error(f"Error triggering pipeline for {table_info}")
-                    if execution_id:
-                        log_updates.append({
-                            "master_execution_id": master_execution_id,
-                            "execution_id": execution_id,
-                            "updates": {
-                                "status": "Failed",
-                                "error_messages": error_msg,
-                            },
-                        })
+                    if extract_utils and execution_id:
+                        try:
+                            log_updates.append({
+                                "master_execution_id": master_execution_id,
+                                "execution_id": execution_id,
+                                "updates": {
+                                    "status": "Failed",
+                                    "error_messages": error_msg,
+                                },
+                            })
+                        except Exception:
+                            logger.debug("Log update failed on trigger error; continuing")
                     return False, error_msg, log_updates
                 
                 logger.info(f"Running {table_info} - Job ID: {job_id}")
@@ -368,29 +371,35 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
                 if poll_success:
                     logger.info(f"{final_state} - {table_info} - Duration: {duration_sec:.2f}s")
                     if extract_utils and execution_id:
-                        log_updates.append({
-                            "master_execution_id": master_execution_id,
-                            "execution_id": execution_id,
-                            "updates": {
-                                "status": "Completed",
-                                "end_timestamp": datetime.now(timezone.utc),
-                                "duration_sec": float(duration_sec),
-                            },
-                        })
+                        try:
+                            log_updates.append({
+                                "master_execution_id": master_execution_id,
+                                "execution_id": execution_id,
+                                "updates": {
+                                    "status": "Completed",
+                                    "end_timestamp": datetime.now(timezone.utc),
+                                    "duration_sec": float(duration_sec),
+                                },
+                            })
+                        except Exception:
+                            logger.debug("Log update failed when marking Completed; continuing")
                     return True, None, log_updates
                 else:
                     logger.warning(f"{final_state} - {table_info} - Duration: {duration_sec:.2f}s")
                     if extract_utils and execution_id:
-                        log_updates.append({
-                            "master_execution_id": master_execution_id,
-                            "execution_id": execution_id,
-                            "updates": {
-                                "status": final_state if final_state else "Failed",
-                                "error_messages": error_msg or "",
-                                "end_timestamp": datetime.now(timezone.utc),
-                                "duration_sec": float(duration_sec),
-                            },
-                        })
+                        try:
+                            log_updates.append({
+                                "master_execution_id": master_execution_id,
+                                "execution_id": execution_id,
+                                "updates": {
+                                    "status": final_state if final_state else "Failed",
+                                    "error_messages": error_msg or "",
+                                    "end_timestamp": datetime.now(timezone.utc),
+                                    "duration_sec": float(duration_sec),
+                                },
+                            })
+                        except Exception:
+                            logger.debug("Log update failed when handling unexpected error; continuing")
                     return False, error_msg, log_updates
                     
             except Exception as exc:

--- a/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
+++ b/ingen_fab/python_libs/pyspark/synapse_orchestrator.py
@@ -520,7 +520,7 @@ class SynapseOrchestrator(SynapseOrchestratorInterface):
         # Bulk flush all log updates in a single MERGE
         if extract_utils is not None and all_log_updates:
             try:
-                extract_utils.update_log_records(all_log_updates)
+                extract_utils.bulk_update_log_records(all_log_updates)
             except Exception as exc:
                 logger.warning(f"Bulk log update failed, continuing: {exc}")
 


### PR DESCRIPTION
### Syanpse sync framework changes
- Reduced polling interval from 60 to 10 seconds as CETAS executions take ~30 seconds
- Reduced jitter to be up to 3 seconds instead of 10. This will reduce pipeline trigger times
- Changed log record update operations to a bulk update at the end of the job. Job runtime now reduced from 2 hours to 15 minutes