### PR TITLE
Change Abstract Filesystem for Extracts

### DIFF
--- a/ingen_fab/python_libs/common/notebookfs_utils.py
+++ b/ingen_fab/python_libs/common/notebookfs_utils.py
@@ -1,0 +1,308 @@
+import os
+import logging
+from dataclasses import dataclass
+from typing import List, Dict, Any, Tuple
+from fnmatch import fnmatch
+
+from notebookutils import mssparkutils # type: ignore
+
+from ingen_fab.python_libs.pyspark.lakehouse_utils import FileInfo
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class FilesystemConnection:
+    """Filesystem client and base URL bundle for dependency injection."""
+    fs: mssparkutils.fs
+    base_url: str
+
+    @classmethod
+    def from_params(cls, connection_params: Dict[str, Any]) -> "FilesystemConnection":
+        """
+        Create connection from connection params.
+
+        Supports:
+        - {"workspace_name": "...", "lakehouse_name": "..."} (OneLake)
+        - {"bucket_url": "abfss://..."} (full ABFSS URL)
+
+        Args:
+            connection_params: Connection parameters dict
+
+        Returns:
+            FilesystemConnection with fs client and base_url
+        """
+        fs, base_url = _get_filesystem_client(connection_params)
+        return cls(fs=fs, base_url=base_url)
+
+def build_onelake_url(workspace_name: str, lakehouse_name: str, path: str = "") -> str:
+    """
+    Build OneLake ABFSS URL from workspace and lakehouse names.
+
+    Args:
+        workspace_name: Fabric workspace name
+        lakehouse_name: Lakehouse name (with or without .Lakehouse suffix)
+        path: Optional path within lakehouse (e.g., "Files/inbound")
+
+    Returns:
+        Full ABFSS URL like: abfss://workspace@onelake.dfs.fabric.microsoft.com/lakehouse.Lakehouse/Files/path
+    """
+    # Ensure lakehouse has .Lakehouse suffix
+    if not lakehouse_name.endswith(".Lakehouse"):
+        lakehouse_name = f"{lakehouse_name}.Lakehouse"
+
+    # Build base URL
+    base_url = f"abfss://{workspace_name}@onelake.dfs.fabric.microsoft.com/{lakehouse_name}"
+
+    # Add path if provided
+    if path:
+        path = path.lstrip("/")
+        return f"{base_url}/{path}"
+
+    return base_url
+
+def _get_filesystem_client(connection_params: Dict[str, Any]) -> Tuple[mssparkutils.fs, str]:
+    """
+    Return mounted mssparkutils filesystem for OneLake using.
+
+    Supports two configuration patterns:
+    1. workspace_name + lakehouse_name → builds OneLake URL
+    2. bucket_url → uses provided ABFSS URL (for flexibility)
+
+    Args:
+        connection_params: Either:
+            - {"workspace_name": "...", "lakehouse_name": "..."}  # OneLake simple
+            - {"bucket_url": "abfss://..."}  # Full ABFSS URL
+
+    Returns:
+        (filesystem_client, base_url)
+
+    Raises:
+        ValueError: If connection_params doesn't match either pattern
+
+    Note:
+        The account_name is automatically extracted from the ABFSS URL by fsspec,
+        so it should NOT be included in connection_params (would cause duplicate key error).
+    """
+
+    # Pattern 1: OneLake simple (workspace/lakehouse names)
+    if "workspace_name" in connection_params and "lakehouse_name" in connection_params:
+        workspace = connection_params["workspace_name"]
+        lakehouse = connection_params["lakehouse_name"]
+
+        # Build OneLake URL
+        bucket_url = build_onelake_url(workspace, lakehouse)
+
+    # Pattern 2: Full ABFSS URL (for flexibility)
+    elif "bucket_url" in connection_params:
+        bucket_url = connection_params["bucket_url"]
+    else:
+        raise ValueError(
+            "connection_params must have either:\n"
+            "  1. workspace_name + lakehouse_name (OneLake simple mode)\n"
+            "  2. bucket_url (full ABFSS URL mode)"
+        )
+
+    #mssparkutils.fs.mount(bucket_url, "/mnt/temp_mount")  # Mount to a temp location to get fs client
+
+    return mssparkutils.fs, bucket_url
+
+def copy_file(
+    source_fs: mssparkutils.fs,
+    source_path: str,
+    dest_fs: mssparkutils.fs,
+    dest_path: str,
+    quietly: bool = False,
+) -> bool:
+    """
+    Copy file from source to destination without deleting source.
+
+    Same as move_file() but leaves the source file in place.
+    Used for watermark-based extraction where files stay at source.
+
+    Args:
+        source_fs: Source filesystem client
+        source_path: Full path to source file
+        dest_fs: Destination filesystem client
+        dest_path: Full path to destination file
+
+    Returns:
+        True if successful, False otherwise
+    """
+    # Create destination directory if needed
+    try:
+        dest_dir = os.path.dirname(dest_path)
+    except Exception as e:
+        logger.error(f"✗ Invalid destination path {dest_path}: {e}")
+        return False
+    
+    # Only attempt to create directory if dest_dir is not empty (i.e., dest_path is not at root)
+    try:
+        if dest_dir and not dest_fs.exists(dest_dir):
+            dest_fs.mkdirs(dest_dir)
+    except Exception as e:
+        logger.error(f"✗ Failed to create destination directory {dest_dir}: {e}")
+        return False
+    
+    # Copy file
+    try:
+        source_fs.cp(source_path, dest_path)
+    except Exception as e:
+        logger.error(f"✗ Failed to copy {source_path} → {dest_path}: {e}")
+        return False
+
+    if not quietly:
+        logger.info(f"✓ Successfully copied {source_path} → {dest_path}")
+    return True
+
+def move_file(
+    source_fs: mssparkutils.fs,
+    source_path: str,
+    dest_fs: mssparkutils.fs,
+    dest_path: str
+) -> bool:
+    """
+    Move file from source to destination using fs.cp() + delete.
+
+    Args:
+        source_fs: Source filesystem client
+        source_path: Full path to source file
+        dest_fs: Destination filesystem client
+        dest_path: Full path to destination file
+
+    Returns:
+        True if successful, False otherwise
+    """
+    # Copy file from source to destination
+    if not copy_file(source_fs, source_path, dest_fs, dest_path, quietly=True):
+        return False
+    
+    try:
+        # Delete source after successful copy
+        source_fs.rm(source_path)
+    except Exception as e:
+        logger.error(f"✗ Failed to delete source file {source_path} after moving: {e}")
+        return False
+
+    logger.info(f"✓ Successfully moved {source_path} → {dest_path}")
+    return True
+
+def glob(
+    fs: mssparkutils.fs,
+    path: str,
+    pattern: str = "*",
+    recursive: bool = True,
+    files_only: bool = True,
+    directories_only: bool = False,
+) -> List[FileInfo]:
+    """
+    Glob files and/or directories using fsspec.
+
+    Args:
+        fs: Filesystem client
+        path: Directory path to search in (should be full ABFSS path)
+        pattern: Glob pattern for matching (default: "*")
+        recursive: Whether to search recursively (default: True)
+        files_only: Return only files (default: True)
+        directories_only: Return only directories (default: False)
+            Note: If both files_only and directories_only are True, returns both
+
+    Returns:
+        List of FileInfo objects with path, name, size, modified_ms
+    """
+    try:
+        files = fs.ls(path)
+    except Exception as e:
+        logger.error(f"Path not found: {path}")
+        return []
+
+    if recursive:
+        all_files = []
+        for file in files:
+            if file.isDir:
+                try:
+                    all_files.extend(fs.ls(file.path))
+                except Exception as e:
+                    logger.error(f"Unable to find sub-path: {path} {e}")
+                all_files.append(file)
+            else:
+                all_files.append(file)
+        files = all_files
+
+    if files_only and not directories_only:
+        files = [f for f in files if f.isFile]
+    elif directories_only and not files_only:
+        files = [f for f in files if f.isDir]
+    else:
+        # If both are True, return all (files and directories)
+        pass
+
+    # Apply glob pattern matching to file names
+    if pattern != "*":
+        files = [f for f in files if fnmatch(os.path.basename(f.name), pattern)]
+
+    return [FileInfo(path=f.path, name=os.path.basename(f.name), size=f.size, modified_ms=f.modifyTime) for f in files]
+
+def file_exists(fs: mssparkutils.fs, file_path: str) -> bool:
+    """
+    Check if file exists using fsspec.
+
+    Args:
+        fs: Filesystem client
+        file_path: Path to file
+
+    Returns:
+        True if file exists, False otherwise
+    """
+    try:
+        return fs.exists(file_path)
+    except Exception:
+        logger.warning(f"Error checking existence of {file_path}")
+        return False
+
+def is_directory_empty(fs: mssparkutils.fs, directory_path: str) -> bool:
+    """
+    Check if directory is empty using fsspec.
+
+    Args:
+        fs: Filesystem client
+        directory_path: Path to directory
+
+    Returns:
+        True if directory is empty or doesn't exist, False otherwise
+    """
+    try:
+        items = fs.ls(directory_path)
+        return len(items) == 0
+    except (FileNotFoundError, Exception):
+        return True  # Directory doesn't exist = empty
+
+def cleanup_empty_directories(
+    fs: mssparkutils.fs,
+    start_path: str,
+    stop_path: str,
+) -> None:
+    """
+    Recursively delete empty directories from start_path up to stop_path.
+
+    Walks up the directory tree from start_path, deleting empty directories
+    until it reaches stop_path or finds a non-empty directory.
+
+    Args:
+        fs: Filesystem client
+        start_path: Starting path (usually a file that was just moved)
+        stop_path: Stop path (usually the base inbound directory)
+    """
+    try:
+        current = os.path.dirname(start_path)
+
+        while current and current != stop_path and current != "/":
+            if is_directory_empty(fs, current):
+                fs.rm(current)
+                logger.debug(f"Deleted empty directory: {current}")
+                current = os.path.dirname(current)
+            else:
+                # Directory not empty - stop climbing
+                break
+    except Exception as e:
+        logger.debug(f"Could not cleanup directories: {e}")

--- a/ingen_fab/python_libs/pyspark/ingestion/extraction/extractors/filesystem_extractor.py
+++ b/ingen_fab/python_libs/pyspark/ingestion/extraction/extractors/filesystem_extractor.py
@@ -9,7 +9,15 @@ import uuid
 from datetime import datetime
 from typing import Generator, List
 
-from ingen_fab.python_libs.common.fsspec_utils import (
+"""from ingen_fab.python_libs.common.fsspec_utils import (
+    FilesystemConnection,
+    cleanup_empty_directories,
+    copy_file,
+    file_exists,
+    glob,
+    move_file,
+)"""
+from ingen_fab.python_libs.common.notebookfs_utils import (
     FilesystemConnection,
     cleanup_empty_directories,
     copy_file,
@@ -554,17 +562,10 @@ class FileSystemExtractor(BaseExtractor[FileSystemExtractionParams], source_type
         """
         try:
             control_path = self._get_control_file_path(file_info)
-            control_info = self.source_fs.info(control_path)
 
-            # Azure returns 'last_modified' or 'LastModified'
-            modified_time = control_info.get("last_modified") or control_info.get("LastModified")
-            if modified_time:
-                if isinstance(modified_time, datetime):
-                    return modified_time
-                else:
-                    from dateutil import parser
-                    return parser.parse(str(modified_time))
-            return None
+            timestamp_ms = self.source_fs.ls(control_path)[0].modifyTime  # Get modified time in milliseconds
+            modified_time = datetime.fromtimestamp(timestamp_ms / 1000)
+            return modified_time
         except Exception as e:
             self.logger.warning(f"Could not get control file modified time for {file_info.path}: {e}")
             return None
@@ -1522,17 +1523,10 @@ Resource: {self.config.resource_name}
         """
         try:
             control_path = f"{folder_info.path.rstrip('/')}/{self.extraction_params.control_file_pattern}"
-            control_info = self.source_fs.info(control_path)
 
-            # Azure returns 'last_modified' or 'LastModified'
-            modified_time = control_info.get("last_modified") or control_info.get("LastModified")
-            if modified_time:
-                if isinstance(modified_time, datetime):
-                    return modified_time
-                else:
-                    from dateutil import parser
-                    return parser.parse(str(modified_time))
-            return None
+            timestamp_ms = self.source_fs.ls(control_path)[0].modifyTime  # Get modified time in milliseconds
+            modified_time = datetime.fromtimestamp(timestamp_ms / 1000)
+            return modified_time
         except Exception as e:
             self.logger.warning(f"Could not get folder control file modified time for {folder_info.path}: {e}")
             return None


### PR DESCRIPTION
I encountered a transient issue where the fsspec copy command would throw the below error when moving or copying a file between onelake container locations:

`2026-04-09 00:21:59 | INFO     | [] [] Found 1 file(s) with control files
2026-04-09 00:21:59 | INFO     | [] [] Discovered 1 files in inbound
2026-04-09 00:22:55 | ERROR    | [] [] ✗ Failed to move  path_a → path_b: An internal error happened due to failed runtime assertion: Parameter 'userToken' is not expected to be null..
ErrorCode:InternalServerError
Content: <?xml version="1.0" encoding="utf-8"?>
<Error>
  <Code>InternalServerError</Code>
  <Message>An internal error happened due to failed runtime assertion: Parameter 'userToken' is not expected to be null..</Message>
</Error>
`

This change swaps out fsspec's abstract file system to the native fabric notebookutils's. The new module - _notebookfs_utils_ - implements the same functions as _fsspec_utils_. This has appeared to resolve the above issue.

The filesystem_extractor has been changed to use this new module. Some code changes were required in the extractor to retrieve modified timestamps from the new abstract filesystem interface. 